### PR TITLE
Working Course Show Page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,16 +14,21 @@ class CoursesController < ApplicationController
     def create
       @course = Course.new(course_params)
       if @course.save
-        redirect_to professors_path, notice: "Course was successfully created."
+        redirect_to courses_path, notice: "Course was successfully created."
       else
         render :new
       end
     end
 
+    def show
+      @course = Course.find(params[:id])
+      @professors = @course.professors  # Fetches all professors associated with the course
+    end
+
     private
   
     def course_params
-      params.require(:course).permit(:name, :code, :description, :professor_id)
+      params.require(:course).permit(:name, :code, :description)
     end
   end
   

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -17,16 +17,33 @@ class ReviewsController < ApplicationController
         end
     end
 
+    # def create
+    #     @review = @professor.reviews.build(review_params)
+    #     @review.student_id = session[:student_id]
+    #     if @review.save
+    #         redirect_to professor_path(@professor), notice: 'Review created successfully.'
+    #     else
+    #         @courses = Course.all
+    #         render :new
+    #     end
+    # end
+
     def create
         @review = @professor.reviews.build(review_params)
         @review.student_id = session[:student_id]
+    
         if @review.save
+            # Ensure the professor-course association exists in the join table
+            unless @professor.courses.exists?(id: @review.course_id)
+                @professor.courses << Course.find(@review.course_id)
+            end
             redirect_to professor_path(@professor), notice: 'Review created successfully.'
         else
             @courses = Course.all
             render :new
         end
     end
+    
 
     private
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,4 +2,5 @@ class Course < ApplicationRecord
     validates_presence_of :name, :code
 
     has_and_belongs_to_many :professors
+    has_many :reviews
 end

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -18,6 +18,8 @@
       <th style="padding: 10px; border-bottom: 2px solid #ddd;">Name</th>
       <th style="padding: 10px; border-bottom: 2px solid #ddd;">Code</th>
       <th style="padding: 10px; border-bottom: 2px solid #ddd;">Description</th>
+      <th style="padding: 10px; border-bottom: 2px solid #ddd;">Details</th>
+
     </tr>
   </thead>
   <tbody>
@@ -26,6 +28,8 @@
         <td style="padding: 10px;"><%= course.name %></td>
         <td style="padding: 10px;"><%= course.code %></td>
         <td style="padding: 10px;"><%= course.description %></td>
+        <td style="padding: 10px;">
+          <%= link_to 'View Details', course_path(course), style: "text-decoration: none; color: #007bff;" %>
       </tr>
     <% end %>
   </tbody>
@@ -34,4 +38,9 @@
 <!-- Link to create a new course -->
 <div style="margin-top: 20px;">
   <%= link_to 'Create a New Course', new_course_path, style: "display: inline-block; padding: 10px 15px; background-color: #28a745; color: white; text-decoration: none; border-radius: 5px;" %>
+</div>
+
+<!-- Link to Professor Search -->
+<div style="margin-top: 20px;">
+  <%= link_to 'Go to Professor Search', professors_path, style: "display: inline-block; padding: 10px 15px; background-color: #28a745; color: white; text-decoration: none; border-radius: 5px;" %>
 </div>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -10,11 +10,6 @@
     </div>
   
     <div>
-      <%= form.label :professor_id, "Select Professor" %>
-      <%= form.collection_select :professor_id, @professors, :id, :name, prompt: "Select a Professor" %>
-    </div>
-  
-    <div>
       <%= form.label :description, "Course Description" %>
       <%= form.text_area :description %>
     </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,0 +1,29 @@
+<h1>Course: <%= @course.name %></h1>
+<p>Course Code: <%= @course.code %></p>
+<p>Description: <%= @course.description %></p>
+
+<h2>Professors Associated with This Course</h2>
+
+<table border="1" cellspacing="0" cellpadding="8" style="width: 100%; text-align: left; border-collapse: collapse;">
+  <thead>
+    <tr>
+      <th style="width: 70%; padding: 8px;">Professor Name</th>
+      <th style="width: 30%; padding: 8px;">Review Page</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @professors.each do |professor| %>
+      <tr>
+        <td style="padding: 8px;"><%= professor.name %></td>
+        <td style="padding: 8px;">
+          <%= link_to 'View Review Page', professor_path(professor), style: "text-decoration: none; color: #007bff;" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<!-- Link to go back to the courses index page -->
+<div style="margin-top: 20px;">
+  <%= link_to 'Back to Courses', courses_path, style: "text-decoration: none; color: #007bff;" %>
+</div>

--- a/app/views/professors/index.html.erb
+++ b/app/views/professors/index.html.erb
@@ -49,3 +49,7 @@
       </tbody>
     </table>
   </div>
+
+  <div style="margin-top: 20px;">
+  <%= link_to 'Go to Courses Search', courses_path, style: "display: inline-block; padding: 10px 15px; background-color: #28a745; color: white; text-decoration: none; border-radius: 5px;" %>
+</div>

--- a/db/migrate/20241126064930_remove_professor_id_from_courses.rb
+++ b/db/migrate/20241126064930_remove_professor_id_from_courses.rb
@@ -1,0 +1,5 @@
+class RemoveProfessorIdFromCourses < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :courses, :professor_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_19_034912) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_26_064930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_19_034912) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "professor_id"
   end
 
   create_table "courses_professors", id: false, force: :cascade do |t|


### PR DESCRIPTION
Addresses the second task in Epic #9 

Created a course show page that lists all the professors associated with that course. I also made some changes to how professors are associated with courses. Before, you could create a new course and specify a professor, but that doesn't really allow for a many to many relationship like we wanted. As a result, I removed the professor column from the courses table. Courses are now associated with professors only through the reviews that students make.

You can find the below page by navigating to the "courses search" button which I have added to the bottom of the professor search home page. 

<img width="1259" alt="Screenshot 2024-11-26 at 9 19 41 AM" src="https://github.com/user-attachments/assets/1b47a94e-7192-4712-8ea9-4a5dc67787a5">

NOTE: When reviewing this PR, you'll likely have to drop, recreate, and migrate the database in order to see all of the changes/new items I made
- docker-compose run web rails db:drop
- docker-compose run web rails db:create
- docker-compose run web rails db:migrate 

Currently, the professor show page displays all reviews, not just the reviews from the selected class.